### PR TITLE
Minor code changes to better support front proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ Example:
 module.exports = {
     "serverListenPort": 8000,
     "serverHost": "192.168.56.100",
-    "serverUrl": "http://192.168.56.100"),
     // ...config file continues from here...
 ```
 If you wish to have live stream support at local network using OBS, set `mediaServer` to `true` and set desired streamKey
@@ -83,14 +82,15 @@ Admin interface is located at: http://localhost:8001/admin
 It accepts the same crendetials as configured at the main app.
 
 ## Environment variables
-| ENV        | default   | Usage                                                 |
-| :--------- | :-------- | :---------------------------------------------------- |
-| PORT       | 8000      | Server listen port                                    |
-| HOST       | localhost | Host or ip, where the server is externally accessible |
-| ADMIN_USER | admin     | Username to access admin interface                    |
-| ADMIN_PASS | admin     | Password for the admin interface                      |
-| USER       | view      | Username to access viewer                             |
-| PASS       | view      | Password to access viewer                             |
+| ENV         | default   | Usage                                                 |
+| :---------- | :-------- | :---------------------------------------------------- |
+| PORT        | 8000      | Server listen port                                    |
+| HOST        | localhost | Host or ip, where the server is externally accessible |
+| ADMIN_USER  | admin     | Username to access admin interface                    |
+| ADMIN_PASS  | admin     | Password for the admin interface                      |
+| USER        | view      | Username to access viewer                             |
+| PASS        | view      | Password to access viewer                             |
+| FRONT_PROXY | false     | Tell software that it's behind a front proxy          |
 
 ## Dockerfile
 

--- a/bin/infoscreen3.js
+++ b/bin/infoscreen3.js
@@ -87,6 +87,6 @@ function onListening() {
         ? 'pipe ' + addr
         : 'port ' + addr.port;
 
-    cli.info('Infoscreen is now accessible at ' + chalk.bold.white(config.serverUrl());
+    cli.info('Infoscreen is now accessible at ' + chalk.bold.white(config.serverUrl()));
     console.log(chalk.green(">>") + chalk.white("Start complete.") + chalk.green("<<"));
 }

--- a/bin/infoscreen3.js
+++ b/bin/infoscreen3.js
@@ -87,6 +87,6 @@ function onListening() {
         ? 'pipe ' + addr
         : 'port ' + addr.port;
 
-    cli.info('Infoscreen is now accessible at ' + chalk.bold.white(config.serverUrl + ":" + config.serverListenPort));
+    cli.info('Infoscreen is now accessible at ' + chalk.bold.white(config.serverUrl());
     console.log(chalk.green(">>") + chalk.white("Start complete.") + chalk.green("<<"));
 }

--- a/config-default.js
+++ b/config-default.js
@@ -2,7 +2,7 @@ export default {
     "serverListenPort": process.env.PORT || 8000,
     "serverHost": process.env.HOST || "127.0.0.1",
     "serverUrl": () => {
-        if (process.env.HTTPS_FRONT_PROXY || false) return "https://" + (process.env.HOST || "127.0.0.1");
+        if (process.env.FRONT_PROXY || false) return "https://" + (process.env.HOST || "127.0.0.1");
         else return "http://" + (process.env.HOST || "127.0.0.1") + ":" + (process.env.PORT || 8000);
     },
     "sessionKey": "generateRandomStringForSecret", // used for encrypting cookies

--- a/config-default.js
+++ b/config-default.js
@@ -1,7 +1,10 @@
 export default {
     "serverListenPort": process.env.PORT || 8000,
     "serverHost": process.env.HOST || "127.0.0.1",
-    "serverUrl": "http://" + (process.env.HOST || "127.0.0.1"),  // used for web client
+    "serverUrl": () => {
+        if (process.env.HTTPS_FRONT_PROXY || false) return "https://" + (process.env.HOST || "127.0.0.1");
+        else return "http://" + (process.env.HOST || "127.0.0.1") + ":" + (process.env.PORT || 8000);
+    },
     "sessionKey": "generateRandomStringForSecret", // used for encrypting cookies
     "streamKey": 'INFOSCREEN3',  // stream key for rtmp end point
     "useLocalAssets": false,    // used to load javascript libraries locally from /public/assets

--- a/routes/index.js
+++ b/routes/index.js
@@ -6,7 +6,7 @@ import cli from '../modules/cli.js';
 import { RateLimiterMemory } from 'rate-limiter-flexible';
 
 const rateLimiter = new RateLimiterMemory({
-    points: 100, // Number of points
+    points: 500, // Number of points
     duration: 1, // Per second
     blockDuration: 60 // one minute
 });

--- a/views/admin/dashboard.twig
+++ b/views/admin/dashboard.twig
@@ -197,7 +197,7 @@
     </div>
 
     <script>
-        var socket = io("{{ config.serverUrl }}:{{ config.serverListenPort }}/admin-{{ displayId }}");
+        var socket = io("{{ config.serverUrl }}/admin-{{ displayId }}");
         var displayId = {{ displayId }};
         var serverUrl = "{{ config.serverUrl }}";
         var askMessage = '{{ t("admin.dashboard.askChangeBundle") }}';

--- a/views/display.twig
+++ b/views/display.twig
@@ -44,7 +44,7 @@
     </video>
 
     <script>
-        var socket = io("{{ config.serverUrl }}:{{ config.serverListenPort }}/display-{{ displayId }}");
+        var socket = io("{{ config.serverUrl }}/display-{{ displayId }}");
         var videoVolume = {{ videoVolume }};
         var isPreview = {{ isPreview }};
     </script>

--- a/views/displayWebGl.twig
+++ b/views/displayWebGl.twig
@@ -48,7 +48,7 @@
     </video>
 
     <script>
-        var socket = io("{{ config.serverUrl }}:{{ config.serverListenPort }}/display-{{ displayId }}");
+        var socket = io("{{ config.serverUrl }}/display-{{ displayId }}");
         var videoVolume = {{ videoVolume }};
         var isPreview = {{ isPreview }};
     </script>

--- a/views/index.twig
+++ b/views/index.twig
@@ -18,7 +18,7 @@
     </div>
 
     <script>
-        var socket = io.connect("{{ config.serverUrl }}:{{ config.serverListenPort }}/lobby");
+        var socket = io.connect("{{ config.serverUrl }}/lobby");
         var intervalId = null;
 
         /** when connected **/

--- a/views/liteDisplay.twig
+++ b/views/liteDisplay.twig
@@ -52,7 +52,7 @@
         var socket = null;
 
         $(function () {
-            socket = io.connect("{{ config.serverUrl }}:{{ config.serverListenPort }}/display-{{ displayId }}");
+            socket = io.connect("{{ config.serverUrl }}/display-{{ displayId }}");
         });
     </script>
     <script src="/js/displayLite.js"></script>

--- a/views/preview.twig
+++ b/views/preview.twig
@@ -21,7 +21,7 @@
     </video>
 
     <script>
-        let socket = io.connect("{{ config.serverUrl }}:{{ config.serverListenPort }}/admin-{{ displayId }}");
+        let socket = io.connect("{{ config.serverUrl }}/admin-{{ displayId }}");
         let socketId = encodeURIComponent("{{ socketId }}");
     </script>
     <script src="/js/preview.js"></script>


### PR DESCRIPTION
When infoscreen3 was placed behind a https terminating front proxy, websocket implementation did not work as expected due to port mapping and protocol issues. These problems come from having port and protocol hard coded to the source code that generates the necessary templates. This patch addresses those problems by making it possible to tell infoscreen3 that it is behind a proxy and server url should be handled in a different manner without hardcoding the port and forcing protocol to be https everywhere.