### PR TITLE
Docker file has invalid command causing error on build 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apk add --no-cache --virtual .gyp python3 make g++ \
 
 # Bundle app source
 COPY . .
-COPY config-default.js config.js
+COPY config.js config.js
 
 # Port will be 8000 by default unless run wih ex. -e PORT=8080
 EXPOSE 8000 8001 1935

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '2'
+services:
+  infoscreen3:
+    build: ./
+    ports:
+      - "8000:8000"
+      - "8001:8001"
+    volumes:
+      - ./data:/usr/src/infoscreen/data
+    env_file: .env


### PR DESCRIPTION
When trying to copy config-default.json the build fails as this file no longer exists

Added new docker-compose.yml file to simplify docker deployment

Uses bind mounts for data to allow persistance between images

Deploy using `docker compose up -d --build` after editing the .env
