### PR TITLE
Add customizable guardrails into the edit slide canvas

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,4 @@ ADMIN_USER="admin"
 ADMIN_PASS="admin"
 LOCALE=en
 MEDIASERVER=false
+GUARDRAILS='[{"line": [240, 0, 240, 1080]}, {"line": [1680, 0, 1680, 1080]}]'

--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ It accepts the same crendetials as configured at the main app.
 | STREAMKEY   | INFOSCREEN3 | streamkey used at OBS                                 |
 | MEDIASERVER | false       | use streaming feature                                 |
 | LOCALE      | en          | available locales: en, fi                             |
-| ACCESSKEY   | &lt;not set&gt;   | use accesskey to access views                         |
+| ACCESSKEY   | &lt;not set&gt;   | use accesskey to access views                   |
+| GUARDRAILS  | '[{"line": [240, 0, 240, 1080]}, {"line": [1680, 0, 1680, 1080]}]'  | Adds additional guardrails into the grid editor. The defaults are for a 4:3 ratio allowing slides to be created for older projectors. In addition to the `line` property the provided json also takes optional input of the `stroke` color, `strokeWidth` width and `opacity` opacity of the guardrails |
 
 To use access key edit the environment variable `ACCESSKEY=yourkey` to `.env`-file.
 After you have set the access key you can use it like this:

--- a/config.js
+++ b/config.js
@@ -7,6 +7,25 @@ const port = 8000;        // port for infoscreen
 let hostUrl = "http://" + (process.env.HOST || host) + ":" + (process.env.PORT || port);
 if (process.env.FRONT_PROXY == "true") hostUrl = "https://" + (process.env.HOST || host);
 
+// By default add 4:3 guardrails to have a backward compatible behavior
+// Allow any kind of other line to be configured in a json representation
+// of this array in the .env file
+let guardRails = [{
+    line: [240, 0, 240, 1080],
+    stroke: "#ccc",
+    strokeWidth: 4,
+    opacity: 0.5
+},
+{
+    line: [1680, 0, 1680, 1080],
+    stroke: "#ccc",
+    strokeWidth: 4,
+    opacity: 0.5
+}]
+if (process.env.GUARDRAILS) {
+    guardRails = JSON.parse(process.env.GUARDRAILS)
+}
+
 export default {
     "serverListenPort": process.env.PORT || port,
     "serverHost": process.env.HOST || host,
@@ -17,6 +36,7 @@ export default {
     "mediaServer": (process.env.MEDIASERVER == "true") ? true : false,       // local streaming server for rtmp, see docs how to use
     "defaultLocale": process.env.LOCALE || "en",      // currently supported values are: "en","fi"
     "accesskey": process.env.ACCESSKEY || false,
+    "guardRails": guardRails,
     /*
      * Plugins
      */

--- a/modules/admin.js
+++ b/modules/admin.js
@@ -458,7 +458,7 @@ export default class admin {
                     json = bundle.getSlideJsonFile(data.fileName);
                     slide = bundle.findSlideByUuid(data.fileName);
                 }
-                socket.emit("callback.edit", {bundleData: bundleData, slideData: slide, json: json, templates: templateData});
+                socket.emit("callback.edit", {bundleData: bundleData, slideData: slide, json: json, templates: templateData, guardRails: config.guardRails});
             });
 
             /** rename **/

--- a/public/js/edit.js
+++ b/public/js/edit.js
@@ -9,6 +9,7 @@ let slideName = "untitled";
 let undoData = [];
 let undoActive = false;
 let templates = {};
+let guardRails = []
 
 
 bundleData = {
@@ -346,6 +347,7 @@ socket.on('callback.edit.updateFileList', function (data) {
 
 socket.on('callback.edit', function (data) {
     bundleData = data.bundleData;
+    guardRails = data.guardRails;
     slideData = data.slideData;
     templates = data.templates;
     canvas.clear();
@@ -539,24 +541,17 @@ function drawGrid() {
         }));
     }
 
-    // Add 4:3 grid highlight to assist on projectors which are "square"
-    canvas.add(new fabric.Line([240, 0, 240, 1080], {
-        stroke: '#ccc',
-        strokeDashArray: [w, w],
-        strokeWidth: 4,
-        opacity: 0.5,
-        selectable: false,
-        zIndex: -1
-    }));
-    canvas.add(new fabric.Line([1680 ,0, 1680, 1080], {
-        stroke: '#ccc',
-        strokeDashArray: [w, w],
-        strokeWidth: 4,
-        opacity: 0.5,
-        selectable: false,
-        zIndex: -1
-    }));
-
+    // Add configured guardrails for the grid to assist on other resoltions
+    guardRails.forEach((guardRail) => {
+        canvas.add(new fabric.Line(guardRail.line, {
+            stroke: guardRail.stroke || '#ccc',
+            strokeDashArray: [w, w],
+            strokeWidth: guardRail.strokeWidth || 4,
+            opacity: guardRail.opacity || 0.5,
+            selectable: false,
+            zIndex: -1
+        }));
+    })
     canvas.renderAll();
 }
 


### PR DESCRIPTION
This tries to mitigate the need for a completely different canvas size which might have been the intention of #31 

I first implemented that, as our event has slightly different resolutions for the projectors and the TVs used as info screens.
This would however result in slides not being really reusable, as they are only saved in the rendered resolution of the last save. So editing it on one screen might end up breaking the other one and vice versa.

So here is an easy way to support multiple resolutions by adding the ability to customize guardrails that will be added into the editing cavas. As a default I added the existing 4:3 ones to not break any existing uses that are not updating their .env file with the new one. So now any slides can be created with the guard lines in mind to have it look pretty on all of our needed resolutions.

Please let me know if I should adjust something. The json based env variable isn't necessarily the best way of handling it, but keeping all config in one file is still the easiest way.