### PR TITLE
Fix deleting bundle with same name throwing error

### DIFF
--- a/routes/admin.js
+++ b/routes/admin.js
@@ -166,7 +166,15 @@ export default function (pluginManager, websocket, dispatcher) {
             if (fields.hasOwnProperty("sDelete")) {
                 let dir = `./data/bundles/${fields.bundle}/`;
                 if (fs.existsSync(dir)) {
-                    fse.moveSync(dir, `./trash/${fields.bundle}/`);
+                    let trashDir = `./trash/${fields.bundle}/`;
+                    if (fs.existsSync(trashDir)) {
+                        let i = 0;
+                        while(fs.existsSync(trashDir)) {
+                            i++;
+                            trashDir = `./trash/${fields.bundle}_${i}`;
+                        }
+                    }
+                    fse.moveSync(dir, trashDir);
                     bundleManager.syncBundles();
                     cli.success(dir, "Bundle removed");
                 } else {


### PR DESCRIPTION
Deleting twice a bundle with the same name attempts to move the bundle directory into the already existing folder inside of the .trash. This will cause an exception to occur and the bundle won't be removed.
I've added a simple check for existence and enumerate those affected newly deleted folders with a _1, _2... until a not yet existing directory is found.