### PR TITLE
Fix various crashes in case all bundles have been dropped

### DIFF
--- a/modules/bundleManager.js
+++ b/modules/bundleManager.js
@@ -50,10 +50,11 @@ export default class bundleManager {
     }
 
     moveSlide(fromBundle, toBundle, uuid, position) {
-        let slideData = this.getBundle(fromBundle).moveTo(toBundle, uuid);
+        let fromBundleObj = this.getBundle(fromBundle);
+        let slideData = fromBundleObj?.moveTo(toBundle, uuid);
         let bundle = this.getBundle(toBundle);
-        slideData.index = position;
-        if (slideData) {
+        if (slideData && bundle) {
+            slideData.index = position;
             bundle.allSlides.push(slideData);
             bundle.save();
         }
@@ -64,10 +65,10 @@ export default class bundleManager {
         let bundle = this.getBundle(bundleName);
         let i = 0;
         for (let uuid of sortedIDs) {
-            bundle.setIndex(uuid, i);
+            bundle?.setIndex(uuid, i);
             i += 1;
         }
-        bundle.save();
+        bundle?.save();
     }
 
     /**

--- a/modules/display.js
+++ b/modules/display.js
@@ -78,7 +78,7 @@ export default class display {
 
         dispatcher.on("display.recalcBundleData", function (bundleName) {
             if (self.serverOptions.currentBundle === bundleName) {
-                for (let slide of self.getBundle().allSlides) {
+                for (let slide of self.getBundle()?.allSlides) {
                     // calculate new index for next slide;
                     if (slide.uuid === self.serverOptions.currentFile) {
                         self.serverOptions.loopIndex = slide.index + 1;
@@ -143,21 +143,23 @@ export default class display {
     changeBundle(bundleName) {
         this.serverOptions.currentBundle = bundleName;
         let bundle = this.getBundle();
-        this.serverOptions.loopIndex = 0;
-        this.serverOptions.currentFile = bundle.enabledSlides[0] || "";
-        this.serverOptions.currentMeta = bundle.findSlideByUuid(bundle.enabledSlides[0]);
-        this.serverOptions.slideDuration = bundle.getBundleData().duration;
-        this.serverOptions.currentId = bundle.enabledSlides.indexOf(this.serverOptions.currentFile);
-        this.serverOptions.transition = bundle.getBundleData().transition;
-        this.serverOptions.loop = true;
-        this.io.emit("callback.load", this.getSlideData());
+        if (bundle) {
+            this.serverOptions.loopIndex = 0;
+            this.serverOptions.currentFile = bundle.enabledSlides[0] || "";
+            this.serverOptions.currentMeta = bundle.findSlideByUuid(bundle.enabledSlides[0]);
+            this.serverOptions.slideDuration = bundle.getBundleData().duration;
+            this.serverOptions.currentId = bundle.enabledSlides.indexOf(this.serverOptions.currentFile);
+            this.serverOptions.transition = bundle.getBundleData().transition;
+            this.serverOptions.loop = true;
+            this.io.emit("callback.load", this.getSlideData());
+        }
         bundle = null;
         this.mainLoop();
     }
 
     getSlideData() {
         let bundle = this.getBundle();
-        return { bundleData: bundle.getBundleData(), slides: bundle.allSlides, serverOptions: this.serverOptions };
+        return { bundleData: bundle?.getBundleData(), slides: bundle?.allSlides, serverOptions: this.serverOptions };
     }
 
     /**
@@ -171,7 +173,7 @@ export default class display {
      * @return {bundle}
      */
     getBundle() {
-        return this.bundleManager.getBundle(this.serverOptions.currentBundle);
+        return this.bundleManager?.getBundle(this.serverOptions.currentBundle);
     }
 
     toggleBlackout() {
@@ -205,6 +207,9 @@ export default class display {
         this.serverOptions.announceMeta = {};
 
         let bundle = this.getBundle();
+        if (!bundle) {
+            return
+        }
         let slides = bundle.getEnabledSlides();
 
         if (slides.length >= 0) {


### PR DESCRIPTION
In case someone delete all available bundles (or at least the one still active on a display), there were several places that crashed the app in case someone clicked a button.
Having no bundles at all was also resulting in a cash on starting the app itself.

Now most places should be safeguarded either by if statements, optional chaining or proper exceptions related to the not existing bundles.