### PR TITLE
Fix connection to lobby socket

### DIFF
--- a/modules/adminLobby.js
+++ b/modules/adminLobby.js
@@ -105,13 +105,18 @@ export default class adminLobby {
             socket.on('controls.pause', function (data) {
                 getAdminView(data.displayId).controls("pause");
             });
-
-            dispatcher.on("dashboard.update", function (data) {
+            
+            cli.info('admin lobby adding dispatcher on dashboard.update count:' + dispatcher.rawListeners("dashboard.update").length);
+            let dashboardUpdateHandler = function (data) {
                 socket.emit("callback.serverOptions", [data]);
-            });
+            };
+            dispatcher.on("dashboard.update", dashboardUpdateHandler);
 
+            socket.on("disconnect", function (s) {
+                dispatcher.removeListener('dashboard.update', dashboardUpdateHandler);
+                cli.info("admin lobby socket disconnect");
+            })
         });
-
         function updateSlides(bundleName, bundleData) {
             for (let aView of adminView) {
                 aView.updateSlides();

--- a/views/admin/overview.twig
+++ b/views/admin/overview.twig
@@ -3,7 +3,7 @@
 {% block header %}
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.6.0/socket.io.min.js"></script>
     <script>
-       var socket = io("{{ config.serverUrl }}/admin-{{ displayId }}");
+       var socket = io("{{ config.serverUrl }}/admin");
     </script>
 {% endblock %}
 


### PR DESCRIPTION
The admin lobby page (/admin) did not  connect to the right socket io namespace, therefore the controls like pause or go to the next slide were not doing anything.

There is no displayId when starting this page and it is also not relevant for the namespace, as all events inside will also expect a displayId as part of the message. 
Was most likely an unlucky copy&paste error while as the same line is used in the other views.