### PR TITLE
Fix stream url to match doc, make sure port is int

### DIFF
--- a/modules/admin.js
+++ b/modules/admin.js
@@ -134,7 +134,7 @@ export default class admin {
                     serverOptions.loop = false;
                     // changed next line from http:// to ws://, to reduce stream lag                    
 
-                    serverOptions.streamSource = "http://" + config.serverHost + ":" + (config.serverListenPort + 1) + "//" + config.streamKey + ".flv";
+                    serverOptions.streamSource = "http://" + config.serverHost + ":" + (parseInt(config.serverListenPort) + 1) + "/live/" + config.streamKey + ".flv";
                     serverOptions.isStreaming = true;
                     cli.success("start stream");
                 } else {


### PR DESCRIPTION
The readme points towards using the `rtmp://localhost/live` endpoint, therefore the streams will end up at the /live/ endpoint of the node media server. (Previous version of this line also contained the `/live/`)
Also the `serverListenPort might sometimes be a string, so making sure it is a number before the +1 to not just append 1 to the port instead of using numerical addition 